### PR TITLE
Add config option to disable flicker limit disabler mixin

### DIFF
--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModClientConfig.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModClientConfig.java
@@ -20,7 +20,7 @@ public class ModClientConfig
     static {
         BUILDER.push("Configs for Create: Tweaked Controllers");
 
-        USE_CUSTOM_MAPPINGS = BUILDER.comment("Wether or not to use custom axis/button mappings, default is false")
+        USE_CUSTOM_MAPPINGS = BUILDER.comment("Whether or not to use custom axis/button mappings, default is false")
             .define("use_custom_mappings", false);
         TOGGLE_MOUSE_FOCUS = BUILDER.comment("Does the mouse cursor focus key acts as toggle instead of hold, default is false")
             .define("toggle_mouse_focus", false);

--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModCommonConfig.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModCommonConfig.java
@@ -1,0 +1,22 @@
+package com.getitemfromblock.create_tweaked_controllers.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+
+public class ModCommonConfig
+{
+    public static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+    public static final ModConfigSpec SPEC;
+
+    public static final ModConfigSpec.ConfigValue<Boolean> DISABLE_FLICKER_LIMIT;
+
+    static {
+        BUILDER.push("Configs for Create: Tweaked Controllers");
+
+        DISABLE_FLICKER_LIMIT = BUILDER.comment("If true, this prevents kinetic blocks from breaking when being updated too fast, default is true")
+                .define("disable_flicker_limit", true);
+
+        BUILDER.pop();
+        SPEC = BUILDER.build();
+    }
+}

--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModConfigs.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModConfigs.java
@@ -10,5 +10,7 @@ public class ModConfigs
     public static void register(ModContainer container)
     {
         container.registerConfig(ModConfig.Type.CLIENT, ModClientConfig.SPEC, CreateTweakedControllers.ID.replace("_", "") + "-client.toml");
+
+        container.registerConfig(ModConfig.Type.COMMON, ModCommonConfig.SPEC, CreateTweakedControllers.ID.replace("_", "") + "-common.toml");
     }
 }

--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/mixin/KineticBlockEntityMixin.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/mixin/KineticBlockEntityMixin.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.simibubi.create.content.kinetics.base.KineticBlockEntity;
+import com.getitemfromblock.create_tweaked_controllers.config.ModCommonConfig;
 
 @Mixin(KineticBlockEntity.class)
 public class KineticBlockEntityMixin
@@ -13,6 +14,9 @@ public class KineticBlockEntityMixin
     @Inject(method = "getFlickerScore", at = @At("HEAD"), cancellable = true, remap = false)
     private void getFlickerScoreMixin(CallbackInfoReturnable<Integer> callback)
     {
-        callback.setReturnValue(0);
+        if (ModCommonConfig.DISABLE_FLICKER_LIMIT.get())
+        {
+            callback.setReturnValue(0);
+        }
     }
 }


### PR DESCRIPTION
Tweaked Controllers adds a mixin to disable Create's behavior of breaking kinetic blocks that update too fast. Since this changes the base Create mod behavior, it should be under a config option, which this PR adds. In some cases it might be desirable to keep the vanilla behavior (I have a need for this, hence the PR). 

This also fixes a typo in the client config.