### PR TITLE
Springback + invert focus

### DIFF
--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModClientConfig.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/config/ModClientConfig.java
@@ -9,6 +9,7 @@ public class ModClientConfig
 
     public static final ForgeConfigSpec.ConfigValue<Boolean> USE_CUSTOM_MAPPINGS;
     public static final ForgeConfigSpec.ConfigValue<Boolean> TOGGLE_MOUSE_FOCUS;
+    public static final ForgeConfigSpec.ConfigValue<Boolean> INVERT_MOUSE_FOCUS;
     public static final ForgeConfigSpec.ConfigValue<Boolean> AUTO_RESET_MOUSE_FOCUS;
     //public static final ForgeConfigSpec.ConfigValue<Boolean> AUTO_DETECT_INPUT_TYPE;
     public static final ForgeConfigSpec.ConfigValue<Integer> CONFIG_BUTTON_MAIN_MENU_ROW;
@@ -24,6 +25,8 @@ public class ModClientConfig
             .define("use_custom_mappings", false);
         TOGGLE_MOUSE_FOCUS = BUILDER.comment("Does the mouse cursor focus key acts as toggle instead of hold, default is false")
             .define("toggle_mouse_focus", false);
+        INVERT_MOUSE_FOCUS = BUILDER.comment("Inverts the mouse focus behaviour: mouse is grabbed immediately when the controller is active, and released while the focus key (Alt by default) is held, default is false")
+            .define("invert_mouse_focus", false);
         AUTO_RESET_MOUSE_FOCUS = BUILDER.comment("Does the mouse cursor inputs are automatically reset when the controller item is put down, default is true")
             .define("auto_reset_mouse_focus", true);
         //AUTO_DETECT_INPUT_TYPE = BUILDER.comment("Does the mod will automatically change the controller profile dependind on what is available on your computer, default is true")

--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/controller/TweakedControlsUtil.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/controller/TweakedControlsUtil.java
@@ -23,7 +23,7 @@ public class TweakedControlsUtil
 
     public static void FreeFocus()
     {
-        isFocusActive = false;
+        isFocusActive = ModClientConfig.INVERT_MOUSE_FOCUS.get() && ModClientConfig.TOGGLE_MOUSE_FOCUS.get();
         lastFocusKeyState = false;
         wasFocusActive = false;
     }
@@ -70,7 +70,29 @@ public class TweakedControlsUtil
 
     private static void HandleMouseKeyBinds()
     {
-        if (ModClientConfig.TOGGLE_MOUSE_FOCUS.get())
+        if (ModClientConfig.INVERT_MOUSE_FOCUS.get())
+        {
+            if (ModClientConfig.TOGGLE_MOUSE_FOCUS.get())
+            {
+                if (ControlsUtil.isActuallyPressed(ModKeyMappings.KEY_MOUSE_FOCUS))
+                {
+                    if (!lastFocusKeyState)
+                    {
+                        lastFocusKeyState = true;
+                        isFocusActive = !isFocusActive;
+                    }
+                }
+                else
+                {
+                    lastFocusKeyState = false;
+                }
+            }
+            else
+            {
+                isFocusActive = !ControlsUtil.isActuallyPressed(ModKeyMappings.KEY_MOUSE_FOCUS);
+            }
+        }
+        else if (ModClientConfig.TOGGLE_MOUSE_FOCUS.get())
         {
             if (ControlsUtil.isActuallyPressed(ModKeyMappings.KEY_MOUSE_FOCUS))
             {

--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/gui/InputConfig/KeyboardInputScreen.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/gui/InputConfig/KeyboardInputScreen.java
@@ -5,13 +5,26 @@ import com.getitemfromblock.create_tweaked_controllers.input.KeyboardInput;
 
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Checkbox;
+import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 
 public class KeyboardInputScreen extends GenericInputScreen
 {
     public KeyboardInput source;
-    private Checkbox box;
+
+    private Checkbox invertBox;
+    private Checkbox springbackEnabledBox;
+
+    private Checkbox isExponentialBox;
+    private Checkbox useGlobalRateBox;
+
+    private EditBox globalRateBox;
+    private EditBox riseRateBox;
+    private EditBox fallRateBox;
+    private EditBox holdTimeBox;
+
+    private int labelWidth = 0;
 
     public KeyboardInputScreen(Screen parent, Component name, KeyboardInput s)
     {
@@ -20,18 +33,131 @@ public class KeyboardInputScreen extends GenericInputScreen
     }
 
     @Override
+    public void tick()
+    {
+        globalRateBox.tick();
+        riseRateBox.tick();
+        fallRateBox.tick();
+        holdTimeBox.tick();
+        super.tick();
+    }
+
+    @Override
     protected void renderWindow(GuiGraphics graphics, int x, int y, float partialTicks)
     {
         super.renderWindow(graphics, x, y, partialTicks);
-        source.invertValue = box.selected();
+
+        source.invertValue = invertBox.selected();
+        source.springbackEnabled = springbackEnabledBox.selected();
+
+        boolean sbEnabled = source.springbackEnabled;
+
+        isExponentialBox.visible = sbEnabled;
+        useGlobalRateBox.visible = sbEnabled;
+
+        boolean exponential = isExponentialBox.selected();
+        boolean useGlobal   = useGlobalRateBox.selected();
+
+        source.springback.isExponential = exponential;
+        source.springback.useGlobalRate = useGlobal;
+
+        setBoxState(globalRateBox, sbEnabled && useGlobal);
+        setBoxState(riseRateBox,   sbEnabled && !useGlobal);
+        setBoxState(fallRateBox,   sbEnabled && !useGlobal);
+        setBoxState(holdTimeBox,   sbEnabled);
+
+        if (sbEnabled) {
+            if (useGlobal) {
+                source.springback.globalRate = ParseFloatAndCorrectValue(globalRateBox);
+            } else {
+                source.springback.riseRate = ParseFloatAndCorrectValue(riseRateBox);
+                source.springback.fallRate = ParseFloatAndCorrectValue(fallRateBox);
+            }
+            source.springback.holdTime = ParseFloatAndCorrectValue(holdTimeBox);
+        }
+
+        int cx = width / 2;
+        int startY = height / 2 - 115;
+
+        if (sbEnabled && useGlobal) {
+            graphics.drawString(font,
+                CreateTweakedControllers.translateDirect("gui_config_springback_globalrate"),
+                cx - labelWidth, startY + 105, 0xaaaaaa);
+        }
+        if (sbEnabled && !useGlobal) {
+            graphics.drawString(font,
+                CreateTweakedControllers.translateDirect("gui_config_springback_riserate"),
+                cx - labelWidth, startY + 105, 0xaaaaaa);
+            graphics.drawString(font,
+                CreateTweakedControllers.translateDirect("gui_config_springback_fallrate"),
+                cx - labelWidth, startY + 130, 0xaaaaaa);
+        }
+        if (sbEnabled) {
+            graphics.drawString(font,
+                CreateTweakedControllers.translateDirect("gui_config_springback_holdtime"),
+                cx - labelWidth, startY + 155, 0xaaaaaa);
+        }
+    }
+
+    private static void setBoxState(EditBox box, boolean active)
+    {
+        box.visible = active;
+        box.setEditable(active);
+        if (!active) box.setFocused(false);
     }
 
     @Override
     protected void Populate()
     {
-        box = new Checkbox(width / 2 - 60, height/2 - 10, 100, 20,
+        int cx = width / 2;
+        int startY = height / 2 - 115;
+
+        invertBox = new Checkbox(cx - 100, startY, 200, 20,
             CreateTweakedControllers.translateDirect("gui_config_invert"), source.invertValue);
-        addRenderableWidget(box);
+        addRenderableWidget(invertBox);
+
+        springbackEnabledBox = new Checkbox(cx - 100, startY + 25, 200, 20,
+            CreateTweakedControllers.translateDirect("gui_config_springback_enabled"), source.springbackEnabled);
+        addRenderableWidget(springbackEnabledBox);
+
+        isExponentialBox = new Checkbox(cx - 100, startY + 50, 200, 20,
+            CreateTweakedControllers.translateDirect("gui_config_springback_exponential"), source.springback.isExponential);
+        addRenderableWidget(isExponentialBox);
+
+        useGlobalRateBox = new Checkbox(cx - 100, startY + 75, 200, 20,
+            CreateTweakedControllers.translateDirect("gui_config_springback_useglobalrate"), source.springback.useGlobalRate);
+        addRenderableWidget(useGlobalRateBox);
+
+        globalRateBox = new EditBox(font, cx, startY + 100, 90, 20,
+            CreateTweakedControllers.translateDirect("gui_config_springback_globalrate"));
+        globalRateBox.setValue(GetSafeFloatString(source.springback.globalRate));
+        addRenderableWidget(globalRateBox);
+
+        riseRateBox = new EditBox(font, cx, startY + 100, 90, 20,
+            CreateTweakedControllers.translateDirect("gui_config_springback_riserate"));
+        riseRateBox.setValue(GetSafeFloatString(source.springback.riseRate));
+        addRenderableWidget(riseRateBox);
+
+        fallRateBox = new EditBox(font, cx, startY + 125, 90, 20,
+            CreateTweakedControllers.translateDirect("gui_config_springback_fallrate"));
+        fallRateBox.setValue(GetSafeFloatString(source.springback.fallRate));
+        addRenderableWidget(fallRateBox);
+
+        holdTimeBox = new EditBox(font, cx, startY + 150, 90, 20,
+            CreateTweakedControllers.translateDirect("gui_config_springback_holdtime"));
+        holdTimeBox.setValue(GetSafeFloatString(source.springback.holdTime));
+        addRenderableWidget(holdTimeBox);
+
+        labelWidth = 0;
+        String[] labelKeys = {
+            "gui_config_springback_globalrate",
+            "gui_config_springback_riserate",
+            "gui_config_springback_fallrate",
+            "gui_config_springback_holdtime"
+        };
+        for (String key : labelKeys) {
+            int w = font.width(CreateTweakedControllers.translateDirect(key)) + 10;
+            if (w > labelWidth) labelWidth = w;
+        }
     }
-    
 }

--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/input/AxisSpringback.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/input/AxisSpringback.java
@@ -1,0 +1,100 @@
+package com.getitemfromblock.create_tweaked_controllers.input;
+
+public class AxisSpringback {
+    private static final double TOLERANCE_VALUE = 0.999;
+
+    public boolean isExponential = true;
+
+    // Rates are in seconds
+    public float globalRate = 1.0f;
+    public boolean useGlobalRate = true;
+    public float riseRate = 1.0f;
+    public float fallRate = 1.0f;
+    public float holdTime = 0f;
+
+    private float current = 0f;
+
+    private float holdTimer = 0f;
+    private boolean wasActive = false;
+
+    private long lastNanoTime = -1L;
+
+    public float smooth(float target) {
+        long now = System.nanoTime();
+        float dt;
+        if (lastNanoTime < 0L) {
+            dt = 0.05f * 20f;
+        } else {
+            dt = (float)((now - lastNanoTime) / 1_000_000_000.0) * 20f;
+            if (dt > 10f) dt = 10f;
+        }
+        lastNanoTime = now;
+        return smooth(target, dt);
+    }
+
+    public float smooth(float target, float dt) {
+        float dtSeconds = dt / 20f;
+
+        if (isExponential) {
+            boolean active = target > 0f;
+
+            if (active) {
+                holdTimer = 0f;
+                wasActive = true;
+            } else {
+                if (wasActive) {
+                    holdTimer = holdTime;
+                    wasActive = false;
+                }
+            }
+
+            if (holdTimer > 0f) {
+                holdTimer -= dtSeconds;
+            } else {
+                float rateSeconds = useGlobalRate ? globalRate : ((target >= current) ? riseRate : fallRate);
+                float r = (float)(-Math.log(1.0 - TOLERANCE_VALUE) / rateSeconds);
+                current += (target - current) * (1f - (float)Math.exp(-r * dtSeconds));
+            }
+        } else { // Linear
+            float effectiveRise = 1.0f / (useGlobalRate ? globalRate : riseRate);
+            float effectiveFall = 1.0f / (useGlobalRate ? globalRate : fallRate);
+
+            boolean active = target > 0f;
+
+            if (active) {
+                holdTimer = 0f;
+                wasActive = true;
+                float maxDelta = effectiveRise * dtSeconds;
+                float diff = target - current;
+                if (Math.abs(diff) <= maxDelta)
+                    current = target;
+                else
+                    current += Math.signum(diff) * maxDelta;
+            } else {
+                if (wasActive) {
+                    holdTimer = holdTime;
+                    wasActive = false;
+                }
+
+                if (holdTimer > 0f) {
+                    holdTimer -= dtSeconds;
+                } else {
+                    float maxDelta = effectiveFall * dtSeconds;
+                    float diff = target - current;
+                    if (Math.abs(diff) <= maxDelta)
+                        current = target;
+                    else
+                        current += Math.signum(diff) * maxDelta;
+                }
+            }
+        }
+        return current;
+    }
+
+    public void reset() {
+        current = 0f;
+        holdTimer = 0f;
+        wasActive = false;
+        lastNanoTime = -1L;
+    }
+}

--- a/src/main/java/com/getitemfromblock/create_tweaked_controllers/input/KeyboardInput.java
+++ b/src/main/java/com/getitemfromblock/create_tweaked_controllers/input/KeyboardInput.java
@@ -20,6 +20,8 @@ public class KeyboardInput implements GenericInput
 {
     public int key = GLFW.GLFW_KEY_UNKNOWN;
     public boolean invertValue = false;
+    public boolean springbackEnabled = true;
+    public AxisSpringback springback = new AxisSpringback();
 
     public KeyboardInput(int key)
     {
@@ -40,7 +42,12 @@ public class KeyboardInput implements GenericInput
     @Override
     public float GetAxisValue()
     {
-        return GetButtonValue() ? 1.0f : 0.0f;
+        if (springbackEnabled) {
+            float target = GetButtonValue() ? 1.0f : 0.0f;
+            return springback.smooth(target);
+        } else {
+            return GetButtonValue() ? 1.0f : 0.0f;
+        }
     }
 
     @Override
@@ -66,6 +73,13 @@ public class KeyboardInput implements GenericInput
     {
         buf.writeBoolean(invertValue);
         buf.writeInt(key);
+        buf.writeBoolean(springbackEnabled);
+        buf.writeBoolean(springback.isExponential);
+        buf.writeBoolean(springback.useGlobalRate);
+        buf.writeFloat(springback.globalRate);
+        buf.writeFloat(springback.riseRate);
+        buf.writeFloat(springback.fallRate);
+        buf.writeFloat(springback.holdTime);
     }
 
     @Override
@@ -73,6 +87,13 @@ public class KeyboardInput implements GenericInput
     {
         invertValue = buf.readBoolean();
         key = buf.readInt();
+        springbackEnabled = buf.readBoolean();
+        springback.isExponential = buf.readBoolean();
+        springback.useGlobalRate = buf.readBoolean();
+        springback.globalRate = buf.readFloat();
+        springback.riseRate = buf.readFloat();
+        springback.fallRate = buf.readFloat();
+        springback.holdTime = buf.readFloat();
     }
 
     @Override

--- a/src/main/resources/assets/create_tweaked_controllers/lang/en_us.json
+++ b/src/main/resources/assets/create_tweaked_controllers/lang/en_us.json
@@ -92,7 +92,7 @@
     "create_tweaked_controllers.gui_output_axis": "Output value as axis :",
     "create_tweaked_controllers.gui_input_axis": "Raw axis input value :",
     
-    "create_tweaked_controllers.keybind.mouse_focus" : "Grab mouse movements",
+    "create_tweaked_controllers.keybind.mouse_focus" : "(Un)grab mouse movements",
     "create_tweaked_controllers.keybind.mouse_reset" : "Center mouse cursor",
     "create_tweaked_controllers.keybind.controller_exit" : "Exit controller",
     

--- a/src/main/resources/assets/create_tweaked_controllers/lang/en_us.json
+++ b/src/main/resources/assets/create_tweaked_controllers/lang/en_us.json
@@ -80,6 +80,13 @@
     "create_tweaked_controllers.gui_config_upper": "Upper axis input bound",
     "create_tweaked_controllers.gui_config_isyaxis": "Use Y instead of X input ?",
     "create_tweaked_controllers.gui_config_usevelocity": "Use velocity instead of position ?",
+    "create_tweaked_controllers.gui_config_springback_enabled": "Enable springback",
+    "create_tweaked_controllers.gui_config_springback_exponential": "Exponential smoothing",
+    "create_tweaked_controllers.gui_config_springback_useglobalrate": "Use global rate",
+    "create_tweaked_controllers.gui_config_springback_globalrate": "Global rate",
+    "create_tweaked_controllers.gui_config_springback_riserate": "Rise rate",
+    "create_tweaked_controllers.gui_config_springback_fallrate": "Fall rate",
+    "create_tweaked_controllers.gui_config_springback_holdtime": "Hold time",
     
     "create_tweaked_controllers.gui_output_button": "Output value as button :",
     "create_tweaked_controllers.gui_output_axis": "Output value as axis :",


### PR DESCRIPTION
Added springback (aka slew limiter) options for keyboard inputs. They are designed to smooth out binary keyboard states using linear and exponential interpolation algorithms. Also added an invert focus option for players who prefer to be more immersed (like me).

<img width="854" height="480" alt="Kooha-2026-05-02-04-43-31-optimized" src="https://github.com/user-attachments/assets/6fdc5b0d-a528-40c7-9d51-cf22b3fe9d55" />


<img width="852" height="478" alt="Kooha-2026-05-02-04-27-33-optimized" src="https://github.com/user-attachments/assets/b56686ca-bd87-4ea1-9cad-bcead65c46d2" />

[Kooha-2026-05-02-04-29-52.webm](https://github.com/user-attachments/assets/d2ac4b11-b3b2-4a6d-b235-91caead1339a)
